### PR TITLE
fix: paste error

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -233,19 +233,6 @@ angular.module('raw.controllers', [])
       $scope.$digest();
     });
 
-    $scope.$watch('importMode', function (n,o){
-
-      $scope.parsed = false;
-      $scope.loading = false;
-      $scope.clipboardText = "";
-      $scope.unstacked = false;
-      $scope.text = "";
-      $scope.data = [];
-      $scope.json = null;
-      $scope.worksheets = [];
-      $scope.fileName = null;
-    });
-
     $scope.$watch('dataView', function (n,o){
       if (!$('.parsed .CodeMirror')[0]) return;
       var cm = $('.parsed .CodeMirror')[0].CodeMirror;
@@ -283,7 +270,15 @@ angular.module('raw.controllers', [])
 
     $scope.$watch('importMode', function(){
       // reset
+      $scope.parsed = false;
+      $scope.loading = false;
       $scope.clipboardText = "";
+      $scope.unstacked = false;
+      $scope.text = "";
+      $scope.data = [];
+      $scope.json = null;
+      $scope.worksheets = [];
+      $scope.fileName = null;
       $scope.url = "";
       //$scope.$apply();
     })

--- a/partials/main.html
+++ b/partials/main.html
@@ -1,6 +1,6 @@
 <div class="wrapper">
 
-	<section class="">
+	<section class="" id="load-data">
 
 		<div class="container">
 


### PR DESCRIPTION
There were two functions for `$scope.$watch('importMode')`. First line of data in the 'Paste' section no longer overlaps the placeholder text.