### PR TITLE
fix: prevent dragging elements beyond window

### DIFF
--- a/js/directives.js
+++ b/js/directives.js
@@ -467,7 +467,7 @@ angular.module('raw.directives', [])
 					    helper : 'clone',
 			        revert: 'invalid',
 			        start : onStart,
-							containment: "document"
+				containment: "document"
 			      })
 		     	})
 

--- a/js/directives.js
+++ b/js/directives.js
@@ -466,7 +466,8 @@ angular.module('raw.directives', [])
 			        connectToSortable:'.dimensions-container',
 					    helper : 'clone',
 			        revert: 'invalid',
-			        start : onStart
+			        start : onStart,
+							containment: "document"
 			      })
 		     	})
 


### PR DESCRIPTION
Prevents the dimension elements from being dragged beyond the document.